### PR TITLE
jQuery 4 compatibility - Upgrade wet-boew.js from 4.0.83 to 4.0.85

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "cweagans/composer-patches": "^1.7",
         "oomphinc/composer-installers-extender": "^1.1 || ^2",
         "drupal/core": "11.*",
-        "wet-boew/wet-boew": "4.0.83",
+        "wet-boew/wet-boew": "4.0.85",
         "wet-boew/theme-gcweb": "14.6.0",
         "wet-boew/theme-wet-boew": "4.0.41",
         "wet-boew/theme-base": "4.0.27",


### PR DESCRIPTION
….0.85

as per: https://github.com/wet-boew/wet-boew/issues/9851