### PR TITLE
fix: #3573247 Load theme-gc-intranet/js/theme.min.js 4.0.44 when gc intranet library is active

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "wet-boew/theme-gcweb": "14.6.0",
         "wet-boew/theme-wet-boew": "4.0.41",
         "wet-boew/theme-base": "4.0.27",
-        "wet-boew/theme-gc-intranet": "4.0.43.1",
+        "wet-boew/theme-gc-intranet": "4.0.44",
         "wet-boew/theme-gc-intranet-legacy": "4.0.27",
         "wet-boew/theme-gcwu-fegc": "4.0.27",
         "wet-boew/theme-gcweb-legacy": "4.0.29",

--- a/wxt_library.libraries.yml
+++ b/wxt_library.libraries.yml
@@ -51,6 +51,8 @@ theme-gc-intranet:
       /libraries/theme-gc-intranet/css/gctheme.css: { browsers: { IE: 'gte IE 9', '!IE': true }, minified: true }
       /libraries/theme-gc-intranet/css/gctheme-blue.css: { browsers: { IE: 'gte IE 9', '!IE': true }, minified: true }
       /libraries/theme-gc-intranet/css/wxtfixes.css: { browsers: { IE: 'gte IE 9', '!IE': true }, minified: true }
+  js:
+    /libraries/theme-gc-intranet/js/theme.min.js: { browsers: { IE: 'gte IE 9', '!IE': true }, minified: true }
   dependencies:
     - core/jquery
 
@@ -208,10 +210,10 @@ theme-gc-intranet-dev:
       /libraries/theme-gc-intranet/css/theme.min.css: { browsers: { IE: 'gte IE 9', '!IE': true } }
       /libraries/theme-gc-intranet/css/cdtsfixes.css: { browsers: { IE: 'gte IE 9', '!IE': true } }
       /libraries/theme-gc-intranet/css/gctheme.css: { browsers: { IE: 'gte IE 9', '!IE': true } }
-
+  js:
+    /libraries/theme-gc-intranet/js/theme.min.js: { browsers: { IE: 'gte IE 9', '!IE': true } }
   dependencies:
     - core/jquery
-
 
 theme-gc-intranet-legacy-dev:
   remote: http://wet-boew.github.io

--- a/wxt_library.libraries.yml
+++ b/wxt_library.libraries.yml
@@ -211,7 +211,7 @@ theme-gc-intranet-dev:
       /libraries/theme-gc-intranet/css/cdtsfixes.css: { browsers: { IE: 'gte IE 9', '!IE': true } }
       /libraries/theme-gc-intranet/css/gctheme.css: { browsers: { IE: 'gte IE 9', '!IE': true } }
   js:
-    /libraries/theme-gc-intranet/js/theme.min.js: { browsers: { IE: 'gte IE 9', '!IE': true } }
+    /libraries/theme-gc-intranet/js/theme.js: { browsers: { IE: 'gte IE 9', '!IE': true } }
   dependencies:
     - core/jquery
 


### PR DESCRIPTION
This PR requires that we merge the jQuery4 fixes with the updated fieldflow for the theme-gc-intranet build.
https://github.com/drupalwxt/themes-cdn/pull/1
We will also need to add a composer-extdeps entry with the new tag for theme-gc-intranet for that once tagged and pull this new tag into wxt 6.2.x
https://www.drupal.org/project/wxt/issues/3573247